### PR TITLE
Dynamically generate the config.ini.php file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,6 @@ Then follow the steps below:
 To update the matomo config, you should set environnement variables and use them in the `scripts/config.ini.php.tmpl`.
 For instance, in our template, we can set the `MATOMO_GENERAL_FORCE_SSL` to `1` to enable the `force_ssl` config option.
 
-#### Activating Matomo Tag Manager (TMS)
-
-By default, Matomo TMS is not activated.
-
-If you activate it manually, in your Matomo dashboard, then the plugin will be disabled the next time your application/container will restart.
-
-It is because, the first time the plugin is activated, some databases are created. At the initialization of the application, if these tables are present, then the nav bar tab is not shown. And since this *core plugin* is not activated by default, it is not embedded in the `[General] PluginsInstalled[]` section in the `config/config.ini.php` distributed file.
-
-Thus, if you want to use Matomo TMS, you must set the environment variable `MATOMO_TAG_MANAGER_ENABLED=true`.
-
 #### Activating plugins
 
 Set the environnement variable `MATOMO_PLUGINS` with a comma separated plugin list name. For instance you can enable the DbCommands, AdminCommands and LicenseKeyCommands plugins with `MATOMO_PLUGINS=DbCommands,AdminCommands,LicenseKeyCommands`.

--- a/README.md
+++ b/README.md
@@ -28,21 +28,8 @@ Then follow the steps below:
 
 #### Override Matomo config
 
-The Matomo buildpack [adds some plugins](https://github.com/1024pix/matomo-buildpack/tree/master/plugins) to the official distribution and especially a copy of the Matomo plugin [EnvironmentVariables](https://plugins.matomo.org/EnvironmentVariables).
-
-This extension allows you to specify Matomo config in environment variables instead of the config file.
-
-For example to overwrite the database username and password which is usually defined in the `config/config.ini.php` like this:
-```
-[database]
-username = "root"
-password = "secure"
-```
-using environment variables like this:
-```
-export MATOMO_DATABASE_USERNAME=root
-export MATOMO_DATABASE_PASSWORD=secure
-```
+To update the matomo config, you should set environnement variables and use them in the `scripts/config.ini.php.tmpl`.
+For instance, in our template, we can set the `MATOMO_GENERAL_FORCE_SSL` to `1` to enable the `force_ssl` config option.
 
 #### Activating Matomo Tag Manager (TMS)
 
@@ -53,6 +40,10 @@ If you activate it manually, in your Matomo dashboard, then the plugin will be d
 It is because, the first time the plugin is activated, some databases are created. At the initialization of the application, if these tables are present, then the nav bar tab is not shown. And since this *core plugin* is not activated by default, it is not embedded in the `[General] PluginsInstalled[]` section in the `config/config.ini.php` distributed file.
 
 Thus, if you want to use Matomo TMS, you must set the environment variable `MATOMO_TAG_MANAGER_ENABLED=true`.
+
+#### Activating plugins
+
+Set the environnement variable `MATOMO_PLUGINS` with a comma separated plugin list name. For instance you can enable the DbCommands, AdminCommands and LicenseKeyCommands plugins with `MATOMO_PLUGINS=DbCommands,AdminCommands,LicenseKeyCommands`.
 
 #### Manage Purchased plugins
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To enable, auto-archiving reports processing, set the two environment variables 
 
 ```shell script
 MATOMO_AUTO_ARCHIVING_FREQUENCY=3600 # in seconds
-MATOMO_BASE_URL=https://my-matomo-instance.osc-fr1.scalingo.io # your application base URL
+MATOMO_HOST=my-matomo-instance.osc-fr1.scalingo.io # your application host (the https:// is added automatically)
 ```
 
 Think to disable the `Archive reports when viewed from the browser` option in the "Matomo > System > General settings > Archiving settings" menu.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Then follow the steps below:
 
 #### Override Matomo config
 
-To update the matomo config, you should set environnement variables and use them in the `scripts/config.ini.php.tmpl`.
-For instance, in our template, we can set the `MATOMO_GENERAL_FORCE_SSL` to `1` to enable the `force_ssl` config option.
+To update the matomo config, edit the config file `scripts/config.ini.php.tmpl`.
+If you have secrets, set environnement variables and use them in the `scripts/config.ini.php.tmpl` file. For instance, we set the `MATOMO_SALT` this way.
 
 #### Activating plugins
 

--- a/bin/activate-plugins.sh
+++ b/bin/activate-plugins.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [[ "$MATOMO_TAG_MANAGER_ENABLED" == true ]]; then
-  echo "Activating Matomo Tag Manager..."
-  php console plugin:activate "TagManager"
-fi
-
 if [[ "$MATOMO_PLUGINS" ]]; then
   IFS=',' read -ra plugins <<<"$MATOMO_PLUGINS"
 

--- a/bin/activate-plugins.sh
+++ b/bin/activate-plugins.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-echo "Activating Matomo Tag Manager..."
-
 if [[ "$MATOMO_TAG_MANAGER_ENABLED" == true ]]; then
+  echo "Activating Matomo Tag Manager..."
   php console plugin:activate "TagManager"
+fi
+
+if [[ "$MATOMO_PLUGINS" ]]; then
+  IFS=',' read -ra plugins <<<"$MATOMO_PLUGINS"
+
+  for plugin in "${plugins[@]}"; do
+    plugin_name=${plugin%%:*}
+
+    echo "Activating $plugin_name"
+    php console plugin:activate "$plugin_name"
+  done
 fi
 
 echo "Activating Matomo purchased plugins..."

--- a/bin/activate-plugins.sh
+++ b/bin/activate-plugins.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+if [[ -z "$MATOMO_LICENSE_KEY" ]]; then
+  echo "Not activating purchased plugins because no Matomo plugins API license key defined"
+else
+  if [[ -z "$MATOMO_PURCHASED_PLUGINS" ]]; then
+    echo "No purchased plugins specified. Did you forgotten to set MATOMO_PURCHASED_PLUGINS variable?"
+  else
+    if [ -z "$MATOMO_PLUGINS" ]; then
+        MATOMO_PLUGINS="$MATOMO_PURCHASED_PLUGINS"
+    else
+        MATOMO_PLUGINS="$MATOMO_PLUGINS,$MATOMO_PURCHASED_PLUGINS"
+    fi
+  fi
+fi
+
 if [[ "$MATOMO_PLUGINS" ]]; then
   IFS=',' read -ra plugins <<<"$MATOMO_PLUGINS"
 
@@ -9,26 +23,4 @@ if [[ "$MATOMO_PLUGINS" ]]; then
     echo "Activating $plugin_name"
     php console plugin:activate "$plugin_name"
   done
-fi
-
-echo "Activating Matomo purchased plugins..."
-
-if [[ -z "$MATOMO_LICENSE_KEY" ]]; then
-  echo "Do not fetch purchased plugins because no Matomo plugins API license key defined"
-else
-  if [[ -z "$MATOMO_PURCHASED_PLUGINS" ]]; then
-    echo "No purchased plugins specified. Did you forgotten to set MATOMO_PURCHASED_PLUGINS variable?"
-  else
-    plugins_dir="./plugins"
-
-    mkdir -p "${PWD}/$plugins_dir"
-
-    IFS=',' read -ra plugins <<<"$MATOMO_PURCHASED_PLUGINS"
-    for plugin in "${plugins[@]}"; do
-      plugin_name=${plugin%%:*}
-
-      echo "Activating $plugin_name"
-      php console plugin:activate "$plugin_name"
-    done
-  fi
 fi

--- a/bin/auto-archiving-reports.sh
+++ b/bin/auto-archiving-reports.sh
@@ -8,7 +8,7 @@ else
   echo "Start auto-archiving reports CRON job"
   while true; do
     echo "Archiving reports... "
-    php console core:archive --url "$MATOMO_BASE_URL"
+    php console core:archive --url "https://$MATOMO_HOST"
     echo "done"
     sleep "$MATOMO_AUTO_ARCHIVING_FREQUENCY"
   done

--- a/scalingo.json
+++ b/scalingo.json
@@ -48,8 +48,8 @@
       "required": false,
       "value": 3600
     },
-    "MATOMO_BASE_URL": {
-      "description": "URL of the instance used by the auto-archiving reports job",
+    "MATOMO_HOST": {
+      "description": "Host of the instance used by the auto-archiving reports job",
       "required": false
     },
     "MATOMO_GENERAL_SALT": {

--- a/scalingo.json
+++ b/scalingo.json
@@ -39,10 +39,9 @@
       "description": "Your purchased Matomo plugins",
       "required": false
     },
-    "MATOMO_TAG_MANAGER_ENABLED": {
-      "description": "Boolean to activate or not Matomo Tag Manager module",
+    "MATOMO_PLUGINS": {
+      "description": "The plugins to install",
       "required": false,
-      "value": "true"
     },
     "MATOMO_AUTO_ARCHIVING_FREQUENCY": {
       "description": "Number of seconds between two reports auto-archiving",

--- a/scripts/config.ini.php.tmpl
+++ b/scripts/config.ini.php.tmpl
@@ -13,6 +13,7 @@ session_save_handler = dbtables
 assume_secure_protocol = 1
 proxy_client_headers[] = HTTP_X_FORWARDED_FOR
 force_ssl = 1
+always_load_commands_from_plugin=DbCommands,AdminCommands,LicenseKeyCommands
 <?php if (getenv('MATOMO_SALT')) { ?>
 salt = "<?php echo getenv('MATOMO_SALT') ?>"
 <?php } ?>

--- a/scripts/config.ini.php.tmpl
+++ b/scripts/config.ini.php.tmpl
@@ -12,3 +12,10 @@ port = <?php echo @$db['port'].PHP_EOL; ?>
 session_save_handler = dbtables
 assume_secure_protocol = 1
 proxy_client_headers[] = HTTP_X_FORWARDED_FOR
+force_ssl = 1
+<?php if (getenv('MATOMO_SALT')) { ?>
+salt = "<?php echo getenv('MATOMO_SALT') ?>"
+<?php } ?>
+<?php if (getenv('MATOMO_GENERAL_TRUSTED_HOSTS')) { ?>
+trusted_hosts[] = <?php echo getenv('MATOMO_GENERAL_TRUSTED_HOSTS') ?>
+<?php } ?>

--- a/scripts/config.ini.php.tmpl
+++ b/scripts/config.ini.php.tmpl
@@ -16,6 +16,6 @@ force_ssl = 1
 <?php if (getenv('MATOMO_SALT')) { ?>
 salt = "<?php echo getenv('MATOMO_SALT') ?>"
 <?php } ?>
-<?php if (getenv('MATOMO_GENERAL_TRUSTED_HOSTS')) { ?>
-trusted_hosts[] = <?php echo getenv('MATOMO_GENERAL_TRUSTED_HOSTS') ?>
+<?php if (getenv('MATOMO_HOST')) { ?>
+trusted_hosts[] = <?php echo getenv('MATOMO_HOST') ?>
 <?php } ?>


### PR DESCRIPTION
This is the second part of the work on the buildpack (https://github.com/1024pix/matomo-buildpack/pull/2). 

We now generate the config file dynamically using the environment variables instead on relying on the `EnvironmentVariablesPlugin`. 

Since the buildpack no longer activate the DbCommands, AdminCommands and LicenseKeyCommands plugins, we added a new variable `MATOMO_PLUGINS` to be able to enable them.