### PR TITLE
Add config option [General] multi_server_environment

### DIFF
--- a/scripts/config.ini.php.tmpl
+++ b/scripts/config.ini.php.tmpl
@@ -20,3 +20,6 @@ salt = "<?php echo getenv('MATOMO_SALT') ?>"
 <?php if (getenv('MATOMO_HOST')) { ?>
 trusted_hosts[] = <?php echo getenv('MATOMO_HOST') ?>
 <?php } ?>
+<?php if (getenv('MATOMO_MULTI_SERVER_ENVIRONMENT')) { ?>
+multi_server_environment = "<?php echo getenv('MATOMO_MULTI_SERVER_ENVIRONMENT') ?>"
+<?php } ?>


### PR DESCRIPTION
Modify `scripts/config.ini.php.tmpl` to allow configuration of Matomo general option to support [multi-server environment](https://fr.matomo.org/faq/new-to-piwik/faq_134/) : 
- Matomo: [General] multi_server_environment (0 or 1)
- Scalingo: `MATOMO_MULTI_SERVER_ENVIRONMENT`