### PR TITLE
Fix session save handler misconfiguration

### DIFF
--- a/scripts/config.ini.php.tmpl
+++ b/scripts/config.ini.php.tmpl
@@ -9,7 +9,6 @@ dbname = "<?php echo trim(@$db['path'], '/'); ?>"
 port = <?php echo @$db['port'].PHP_EOL; ?>
 
 [General]
-session_save_handler = dbtables
 assume_secure_protocol = 1
 proxy_client_headers[] = HTTP_X_FORWARDED_FOR
 force_ssl = 1


### PR DESCRIPTION
The `session_save_handler` entry in the generated `config.ini.php` was set to `dbtables`, which is not a valid value — the session save handler provided by Matomo and which writes sessions to the database (allowing sessions to be shared in a multi-server environment) is called `dbtable` (note the absent `s`).

PHP was therefore falling back to its default `files` session save handler, which stores sessions locally on each server, breaking sessions when multiple containers were started unless _sticky sessions_ were enabled, which is suboptimal.

This PR removes the `session_save_handler` configuration from `config.ini.php` altogether, as that is already the default value used by Matomo.