### PR TITLE
Monter de version de Matomo vers la  v4.0.5

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/1024pix/matomo-buildpack#v3.14.1.2
+https://github.com/1024pix/matomo-buildpack#v4.0.5
 https://github.com/Scalingo/php-buildpack

--- a/scripts/config.ini.php.tmpl
+++ b/scripts/config.ini.php.tmpl
@@ -13,6 +13,7 @@ assume_secure_protocol = 1
 proxy_client_headers[] = HTTP_X_FORWARDED_FOR
 force_ssl = 1
 always_load_commands_from_plugin=DbCommands,AdminCommands,LicenseKeyCommands
+enable_trusted_host_check = 0
 
 <?php if (getenv('MATOMO_SALT')) { ?>
 salt = "<?php echo getenv('MATOMO_SALT') ?>"


### PR DESCRIPTION
Du au fait qu'on utilise un PaaS, nous pouvons activer l'option sans risque de sécurité :
 
```tmpl
enable_trusted_host_check = 0
```