### PR TITLE
Utiliser la même configuration dans le containeur d'archive des données que dans les containeurs applicatifs.

### DIFF
--- a/bin/auto-archiving-reports.sh
+++ b/bin/auto-archiving-reports.sh
@@ -3,7 +3,10 @@
 if [[ -z "$MATOMO_AUTO_ARCHIVING_FREQUENCY" ]]; then
   echo "Auto-archiving reports job disabled"
 else
+  bin/fetch-purchased-plugins.sh
   bin/generate-config-ini.sh
+  bin/set-license-key.sh
+  bin/activate-plugins.sh
 
   echo "Start auto-archiving reports CRON job"
   while true; do


### PR DESCRIPTION
# 🦄  Problème 
Actuellement, les configuration générées lors du `bin/start-matomo.sh` et de `bin/auto-archiving-reports.sh` sont différentes. 
Nous pouvons constater que dans cette dernière les plugins ne sont pas présents. De ce fait, les données ne sont pas calculés pour les funnels.

# 🌮  Solution 

Généré la même configuration dans les 2 cas.  