### PR TITLE
[TECH] Enable maintenance mode and disable record statistics when MATOMO_MAINTENANCE set to true.

### DIFF
--- a/scripts/config.ini.php.tmpl
+++ b/scripts/config.ini.php.tmpl
@@ -14,6 +14,9 @@ proxy_client_headers[] = HTTP_X_FORWARDED_FOR
 force_ssl = 1
 always_load_commands_from_plugin=DbCommands,AdminCommands,LicenseKeyCommands
 enable_trusted_host_check = 0
+<?php if (getenv('MATOMO_MAINTENANCE') == 'true') { ?>
+maintenance_mode = 1 
+<?php } ?>
 
 <?php if (getenv('MATOMO_SALT')) { ?>
 salt = "<?php echo getenv('MATOMO_SALT') ?>"
@@ -25,5 +28,10 @@ trusted_hosts[] = <?php echo getenv('MATOMO_HOST') ?>
 
 <?php if (getenv('MATOMO_MULTI_SERVER_ENVIRONMENT')) { ?>
 multi_server_environment = <?php echo getenv('MATOMO_MULTI_SERVER_ENVIRONMENT') ?>
+<?php } ?>
+
+<?php if (getenv('MATOMO_MAINTENANCE') == 'true') { ?>
+[Tracker]
+record_statistics = 0 
 <?php } ?>
 


### PR DESCRIPTION
Activer le mode maintenance et désactiver l'enregistrement des trackings quand la variable d'environnement `MATOMO_MAINTENANCE` est à `true`.